### PR TITLE
Move x4 image publishing into x4-dashboard

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,0 +1,108 @@
+name: Publish Container Images
+
+on:
+  push:
+    tags:
+      - "v*"
+    paths:
+      - "Dockerfile.landing"
+      - "Dockerfile.mock"
+      - "landing/**"
+      - "client/**"
+      - "server/**"
+      - "package.json"
+      - "package-lock.json"
+      - "landing/package.json"
+      - "landing/package-lock.json"
+      - "client/package.json"
+      - "client/package-lock.json"
+      - "server/package.json"
+      - "server/package-lock.json"
+      - ".github/workflows/publish-images.yml"
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: "Git ref to build"
+        required: false
+        type: string
+      image_tag:
+        description: "Image tag to publish, for example v1.5.0"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Resolve target ref
+        id: target
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git_ref="${{ inputs.git_ref }}"
+          if [[ -z "${git_ref}" ]]; then
+            git_ref="${GITHUB_REF}"
+          fi
+
+          if [[ "${git_ref}" == refs/tags/* ]]; then
+            image_tag="${git_ref#refs/tags/}"
+          else
+            image_tag="${{ inputs.image_tag }}"
+          fi
+
+          if [[ -z "${image_tag}" ]]; then
+            echo "image_tag is required for non-tag workflow_dispatch runs." >&2
+            exit 1
+          fi
+
+          echo "git_ref=${git_ref}" >> "${GITHUB_OUTPUT}"
+          echo "image_tag=${image_tag}" >> "${GITHUB_OUTPUT}"
+
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.target.outputs.git_ref }}
+
+      - name: Resolve source commit
+        id: source
+        shell: bash
+        run: |
+          set -euo pipefail
+          source_sha="$(git rev-parse --short=12 HEAD)"
+          echo "source_sha=${source_sha}" >> "${GITHUB_OUTPUT}"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push landing image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.landing
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/x4-dashboard-landing:${{ steps.target.outputs.image_tag }}
+            ghcr.io/${{ github.repository_owner }}/x4-dashboard-landing:sha-${{ steps.source.outputs.source_sha }}
+
+      - name: Build and push mock image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.mock
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/x4-dashboard-mock:${{ steps.target.outputs.image_tag }}
+            ghcr.io/${{ github.repository_owner }}/x4-dashboard-mock:sha-${{ steps.source.outputs.source_sha }}

--- a/README.md
+++ b/README.md
@@ -222,6 +222,13 @@ The project currently has two Dokploy-managed deployment targets:
 - `landing/` through `Dockerfile.landing`
 - mock mode through `Dockerfile.mock`
 
+Tagged releases also publish versioned GHCR images from this repository:
+
+- `ghcr.io/fpiechowski/x4-dashboard-landing:vX.Y.Z`
+- `ghcr.io/fpiechowski/x4-dashboard-mock:vX.Y.Z`
+
+Infrastructure repositories such as `nebula` should consume those published images instead of rebuilding them.
+
 GitHub Pages is no longer part of the active deployment model for this repository.
 
 ## ⚙️ Host Settings

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -44,6 +44,7 @@ npm run desktop:dist
 4. Publish GitHub release notes based on `CHANGELOG.md`
 5. Let `.github/workflows/release.yml` attach the generated server and Lua assets
 6. Let `.github/workflows/release.yml` build and attach Windows desktop installers
+7. Let `.github/workflows/publish-images.yml` publish `x4-dashboard-landing` and `x4-dashboard-mock` images to GHCR for the same release tag
 
 ## Distribution notes
 
@@ -51,3 +52,4 @@ npm run desktop:dist
 - The project is intended for trusted local environments
 - Remote control should stay disabled unless explicitly required
 - Desktop packaging now acts as a server launcher and convenience entry point for browser-based clients
+- `nebula` and other infrastructure repositories should reference the published GHCR images instead of rebuilding this repository


### PR DESCRIPTION
## Summary
- add a repository-owned workflow to publish landing and mock images to GHCR
- document the published image contract in the README and release guide
- keep infrastructure repositories as image consumers only

## Testing
- not run (publishing images would create real GHCR artifacts)