### PR TITLE
Opt publish workflow into Node 24

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,5 +1,8 @@
 name: Publish Container Images
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 on:
   push:
     tags:
@@ -65,7 +68,7 @@ jobs:
           echo "image_tag=${image_tag}" >> "${GITHUB_OUTPUT}"
 
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ steps.target.outputs.git_ref }}
 


### PR DESCRIPTION
## Summary
- opt the publish-images workflow into Node 24 ahead of the GitHub runner default switch
- update actions/checkout to the current major version
- reduce the deprecation warning surface for future image publication runs

## Testing
- git diff --check